### PR TITLE
Add \quad and \qquad spacing commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3w (unreleased)
+
+- implement \quad and \qquad spacing commands.
+
 ## 1.0.2
 
 - fixed matrix spacing

--- a/lib/src/typeset.dart
+++ b/lib/src/typeset.dart
@@ -47,6 +47,23 @@ void typeset(TeXNode node, int fracDepth) {
           // ================ spacing ================
           node.postfixSpacing = tk == '\\,' ? 150 : 300;
           return;
+        } else if (tk == '\\quad' || tk == '\\qquad') {
+          //space depends on "EM"
+          var entry = table["M"] as Map<Object, Object>;
+          var glyph = Glyph();
+          glyph.tk = node.tk;
+
+          if (entry.containsKey("d")) {
+            glyph.x = (entry["d"] as int).toDouble(); // delta x
+          }
+          glyph.width = (entry["w"] as int).toDouble();
+          glyph.height = (entry["h"] as int).toDouble(); //standardFontHeightt
+          node.glyphs.add(glyph);
+          if (tk == '\\qquad') {
+            node.glyphs.add(glyph);
+          }
+          node.calcGeometry();
+          return;
         } else if (functions.contains(tk)) {
           // ================ functions ================
           node.type = TeXNodeType.list;


### PR DESCRIPTION
There are some instances where spacing is needed. For that the \quad and \qquad commands come in handy and they provide spacing equal to the capital M.

